### PR TITLE
Modify the README to reflect proper RISC-V branding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# RISCV-phone
+# RISC-V Phone Hardware
+
+The software for the phone is [here](https://github.com/irandms/riscv-phone-sw).


### PR DESCRIPTION
Link to the phone software in the README as well.